### PR TITLE
Update docker-gen to 0.4.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN gem install fluentd --no-ri --no-rdoc \
 
 # install docker-gen
 RUN cd /usr/local/bin \
-    && curl -L https://github.com/jwilder/docker-gen/releases/download/0.3.7/docker-gen-linux-amd64-0.3.7.tar.gz \
+    && curl -L https://github.com/jwilder/docker-gen/releases/download/0.4.0/docker-gen-linux-amd64-0.4.0.tar.gz \
     | tar -xzv
 
 # add startup scripts and config files


### PR DESCRIPTION
docker-gen 0.4.0 exposes `Labels`.
